### PR TITLE
Ignore empty checks

### DIFF
--- a/__tests__/parse.test.ts
+++ b/__tests__/parse.test.ts
@@ -6,23 +6,31 @@ describe("parseChecksArray", () => {
 
     it("returns an empty array if input is -1", () => {
         expect(parseChecksArray("-1")).toEqual([]);
-    }   );
+    });
 
     it("returns an array of objects if input is a JSON array", () => {
         expect(parseChecksArray('[{"name":"check1","app_id":1},{"name":"check2","app_id":2}]')).toEqual([{name:"check1",app_id:1},{name:"check2",app_id:2}]);
-    }   );
+    });
+
+    it("returns an array of objects if input is a JSON array omitting empty values", () => {
+        expect(parseChecksArray('[{"name":"check1","app_id":1},{"name":"","app_id":-1}]')).toEqual([{name:"check1",app_id:1}]);
+    });
 
     it("returns an array of objects if input is a JSON object", () => {
         expect(parseChecksArray('{"name":"check1","app_id":1}')).toEqual([{name:"check1",app_id:1}]);
-    }   );
+    });
 
     it("returns an array of objects if input is a comma-separated list of check names", () => {
         expect(parseChecksArray('check1,check2')).toEqual([{name:"check1",app_id:-1},{name:"check2",app_id:-1}]);
-    }   );
+    });
 
     it("returns an array of objects if input is a comma-separated list of check names with spaces", () => {
         expect(parseChecksArray('check1, check2')).toEqual([{name:"check1",app_id:-1},{name:"check2",app_id:-1}]);
-    }   );
+    });
+
+    it("returns an array of objects if input is a comma-separated list of check names with extra commas", () => {
+        expect(parseChecksArray('check1,,check2,')).toEqual([{name:"check1",app_id:-1},{name:"check2",app_id:-1}]);
+    });
 
     it("returns an error if input is invalid JSON",()=>{
         expect(()=>parseChecksArray('{"name":"check1","app_id":1')).toThrowError();

--- a/src/utils/inputsExtractor.ts
+++ b/src/utils/inputsExtractor.ts
@@ -74,6 +74,8 @@ export function parseChecksArray(input: string, inputType: string = "checks_incl
 
         const trimmedInput = input.trim();
 
+        let checks: ICheckInput[] = [];
+
         if (trimmedInput === "-1") {
             return [];
         }
@@ -81,25 +83,24 @@ export function parseChecksArray(input: string, inputType: string = "checks_incl
         // attempt to parse as JSON if it starts with { or [
 
         if (trimmedInput.startsWith("{")) {
-
-            let parsedInput = JSON.parse("[" + trimmedInput + "]");
-            if (!validateCheckInputs(parsedInput)) {
-                throw new Error();
-            }
-            return parsedInput;
-        }
-        if (trimmedInput.startsWith("[")) {
-            let parsedInput = JSON.parse(trimmedInput);
-            if (!validateCheckInputs(parsedInput)) {
-                throw new Error();
-            }
-            return parsedInput;
+            checks = JSON.parse("[" + trimmedInput + "]");
+        } else if (trimmedInput.startsWith("[")) {
+            checks = JSON.parse(trimmedInput);
         } else {
-            return trimmedInput.split(',').map(element => {
+            // Split by commas.
+            checks = trimmedInput.split(',').map(element => {
                 return {name: element.trim(), app_id: -1};
             });
         }
 
+        // Remove checks with no filtering ability
+        checks = checks.filter((c) => c.app_id !== -1 || c.name !== '');
+
+        if (!validateCheckInputs(checks)) {
+            throw new Error();
+        }
+
+        return checks;
     } catch (error: any) {
         throw new Error(`Error parsing the ${inputType} input, please provide a comma-separated list of check names, or a valid JSON array of objects with the properties "name" and "app_id"`)
     }


### PR DESCRIPTION
Currently, when the `include_checks` input to `allcheckspassed` includes a trailing comma, such as `foo,bar,baz.*,`, `allcheckspassed` treats this as an additional empty regex (`''`). This empty regex matches all builds.

The net result is that one additional build besides those desired is treated as required.

This PR cleans input by removing all check filters that don't do any meaningful filtering.