### PR TITLE
allow the delay and polling interval values to accept floats

### DIFF
--- a/__tests__/inputs.test.ts
+++ b/__tests__/inputs.test.ts
@@ -1,6 +1,4 @@
-import { validateIntervalValues } from '../src/utils/validators';
-
-
+import {validateIntervalValues} from '../src/utils/validators';
 
 
 describe("validateIntervalValues", () => {
@@ -32,6 +30,14 @@ describe("validateIntervalValues", () => {
 
     it("return 1 if input i negative infinity", () => {
         expect(validateIntervalValues(-Infinity)).toBe(1);
+    });
+
+    it('returns a float if input is a float', () => {
+        expect(validateIntervalValues(1.5)).toBe(1.5);
+        expect(validateIntervalValues(1.1)).toBe(1.1);
+        expect(validateIntervalValues(0.5)).toBe(0.5);
+        expect(validateIntervalValues(0.1)).toBe(0.1);
+        expect(validateIntervalValues(359.9)).toBe(359.9);
     });
 
 });

--- a/src/utils/inputsExtractor.ts
+++ b/src/utils/inputsExtractor.ts
@@ -44,10 +44,10 @@ function inputsParser(): IInputs {
     const failOnMissingChecks: boolean = core.getInput("fail_on_missing_checks") == "true";
     const poll: boolean = core.getInput("poll") == "true";
     const delay: number = validateIntervalValues(
-        parseInt(core.getInput("delay"))
+        parseFloat(core.getInput("delay"))
     );
     const pollingInterval: number = validateIntervalValues(
-        parseInt(core.getInput("polling_interval"))
+        parseFloat(core.getInput("polling_interval"))
     );
     const retries: number = validateIntervalValues(parseInt(core.getInput("retries")));
 


### PR DESCRIPTION
Closes #5 

Allows the delay and polling intervals to take fractional values.