### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -1,6 +1,9 @@
 name: Update Main Version
 run-name: Move ${{ github.event.inputs.major_version }} to ${{ github.event.inputs.target }}
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -12,7 +15,6 @@ on:
         description: The major version to update
         options:
           - v1
-
 
 jobs:
   tag:


### PR DESCRIPTION
Potential fix for [https://github.com/wechuli/allcheckspassed/security/code-scanning/3](https://github.com/wechuli/allcheckspassed/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's tasks, it requires `contents: write` to push tags to the repository. Adding this block ensures that the workflow does not inherit unnecessary permissions from the repository.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `tag` job. In this case, adding it at the root level is sufficient and simplifies the configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
