### PR TITLE
Add support for `pull_request_review` trigger event

### DIFF
--- a/src/utils/inputsExtractor.ts
+++ b/src/utils/inputsExtractor.ts
@@ -30,7 +30,7 @@ export interface IInputs {
 
 function inputsParser(): IInputs {
   const eventName = github.context.eventName;
-  const validPullRequestEvents = ["pull_request", "pull_request_target"];
+  const validPullRequestEvents = ["pull_request", "pull_request_target", "pull_request_review"];
   let headSha: string | undefined = undefined;
   if (validPullRequestEvents.includes(eventName)) {
     headSha = github.context.payload.pull_request?.head.sha as string;


### PR DESCRIPTION
## Motivation
I noticed that this GH Action, when triggered via `pull_request_review` event:
* fails to produce summary
* emits this warning:
  https://github.com/wechuli/allcheckspassed/blob/105c017695fe048b1aaa8a239d60e78dbc7273c0/src/checks/checks.ts#L112-L118
* reports a false-positive result

This is caused by invalid resolution of the PR's HEAD commit SHA, which in turn is needed to fetch check statuses from GitHub API.

## Changes
Add `pull_request_review` to `validPullRequestEvents` so that the GH Action can resolve the `commitSHA` properly.

Note that `pull_request?.head.sha` is defined for `pull_request_review` event the same as it is for `pull_request` and `pull_request_target` events: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=submitted#pull_request_review