### PR TITLE
Filter out check runs from superseded workflow re-runs

### DIFF
--- a/__tests__/checks/checks.test.ts
+++ b/__tests__/checks/checks.test.ts
@@ -48,6 +48,7 @@ describe("Checks", () => {
     delay: 0,
     checkRunId: undefined,
     includeStatusCommits: false,
+    ignoreSupersededRuns: false,
   };
   const mockChecks: ICheck[] = [
     {
@@ -189,6 +190,9 @@ describe("Checks", () => {
       expect(checks["includeStatusCommits"]).toBe(
         defaultProps.includeStatusCommits
       );
+      expect(checks["ignoreSupersededRuns"]).toBe(
+        defaultProps.ignoreSupersededRuns
+      );
     });
   });
 
@@ -275,7 +279,15 @@ describe("Checks", () => {
       expect(checks["allChecks"].length).toBeGreaterThan(mockChecks.length);
     });
 
-    it("should filter out checks from superseded workflow runs", async () => {
+    it("should not call getWorkflowRunsForCommit when ignoreSupersededRuns is false", async () => {
+      const checks = new Checks(defaultProps);
+      await checks.fetchAllChecks();
+
+      expect(getWorkflowRunsForCommitMock).not.toHaveBeenCalled();
+      expect(checks["allChecks"]).toEqual(mockChecks);
+    });
+
+    it("should filter out checks from superseded workflow runs when ignoreSupersededRuns is true", async () => {
       const supersededCheck: ICheck = {
         id: 5000,
         name: "E2E Tests",
@@ -303,9 +315,13 @@ describe("Checks", () => {
         { id: 200, workflow_id: 50, check_suite_id: 901 },
       ]);
 
-      const checks = new Checks(defaultProps);
+      const checks = new Checks({
+        ...defaultProps,
+        ignoreSupersededRuns: true,
+      });
       await checks.fetchAllChecks();
 
+      expect(getWorkflowRunsForCommitMock).toHaveBeenCalled();
       expect(checks["allChecks"]).toHaveLength(1);
       expect(checks["allChecks"][0].id).toBe(4999);
       expect(checks["allChecks"][0].conclusion).toBe(checkConclusion.SUCCESS);
@@ -316,7 +332,10 @@ describe("Checks", () => {
         new Error("API Error")
       );
 
-      const checks = new Checks(defaultProps);
+      const checks = new Checks({
+        ...defaultProps,
+        ignoreSupersededRuns: true,
+      });
       await checks.fetchAllChecks();
 
       expect(checks["allChecks"]).toEqual(mockChecks);
@@ -353,7 +372,10 @@ describe("Checks", () => {
         { id: 200, workflow_id: 50, check_suite_id: 901 },
       ]);
 
-      const checks = new Checks(defaultProps);
+      const checks = new Checks({
+        ...defaultProps,
+        ignoreSupersededRuns: true,
+      });
       await checks.fetchAllChecks();
       await checks.filterChecks();
 

--- a/__tests__/checks/checks.test.ts
+++ b/__tests__/checks/checks.test.ts
@@ -23,6 +23,7 @@ describe("Checks", () => {
 
   // Mock API calls
   let getAllChecksMock: jest.SpyInstance;
+  let getWorkflowRunsForCommitMock: jest.SpyInstance;
   let getAllStatusCommitsMock: jest.SpyInstance;
   let extractOwnCheckNameFromWorkflowMock: jest.SpyInstance;
   let sleepMock: jest.SpyInstance;
@@ -148,6 +149,9 @@ describe("Checks", () => {
     getAllChecksMock = jest
       .spyOn(checksAPI, "getAllChecks")
       .mockResolvedValue(mockChecks);
+    getWorkflowRunsForCommitMock = jest
+      .spyOn(checksAPI, "getWorkflowRunsForCommit")
+      .mockResolvedValue([]);
     getAllStatusCommitsMock = jest
       .spyOn(statusesAPI, "getAllStatusCommits")
       .mockResolvedValue([]);
@@ -269,6 +273,98 @@ describe("Checks", () => {
 
       // Should have both checks and mapped status commits (only most recent per context/creator)
       expect(checks["allChecks"].length).toBeGreaterThan(mockChecks.length);
+    });
+
+    it("should filter out checks from superseded workflow runs", async () => {
+      const supersededCheck: ICheck = {
+        id: 5000,
+        name: "E2E Tests",
+        status: checkStatus.COMPLETED,
+        conclusion: checkConclusion.FAILURE,
+        started_at: "2024-05-14T00:00:00Z",
+        completed_at: "2024-05-14T00:10:00Z",
+        check_suite: { id: 900 },
+        app: { id: 1001, slug: "github-actions", name: "GitHub Actions" },
+      };
+      const freshCheck: ICheck = {
+        id: 4999,
+        name: "E2E Tests",
+        status: checkStatus.COMPLETED,
+        conclusion: checkConclusion.SUCCESS,
+        started_at: "2024-05-14T00:00:00Z",
+        completed_at: "2024-05-14T00:10:00Z",
+        check_suite: { id: 901 },
+        app: { id: 1001, slug: "github-actions", name: "GitHub Actions" },
+      };
+
+      getAllChecksMock.mockResolvedValueOnce([supersededCheck, freshCheck]);
+      getWorkflowRunsForCommitMock.mockResolvedValueOnce([
+        { id: 100, workflow_id: 50, check_suite_id: 900 },
+        { id: 200, workflow_id: 50, check_suite_id: 901 },
+      ]);
+
+      const checks = new Checks(defaultProps);
+      await checks.fetchAllChecks();
+
+      expect(checks["allChecks"]).toHaveLength(1);
+      expect(checks["allChecks"][0].id).toBe(4999);
+      expect(checks["allChecks"][0].conclusion).toBe(checkConclusion.SUCCESS);
+    });
+
+    it("should proceed with all checks when workflow runs API fails", async () => {
+      getWorkflowRunsForCommitMock.mockRejectedValueOnce(
+        new Error("API Error")
+      );
+
+      const checks = new Checks(defaultProps);
+      await checks.fetchAllChecks();
+
+      expect(checks["allChecks"]).toEqual(mockChecks);
+      expect(warningMock).toHaveBeenCalledWith(
+        expect.stringContaining("Could not fetch workflow runs")
+      );
+    });
+
+    it("should not report false failure when superseded run has FAILURE conclusion (issue #104)", async () => {
+      const supersededFailure: ICheck = {
+        id: 5000,
+        name: "E2E Tests",
+        status: checkStatus.COMPLETED,
+        conclusion: checkConclusion.FAILURE,
+        started_at: "2024-05-14T00:00:00Z",
+        completed_at: "2024-05-14T00:10:00Z",
+        check_suite: { id: 900 },
+        app: { id: 1001, slug: "github-actions", name: "GitHub Actions" },
+      };
+      const freshSuccess: ICheck = {
+        id: 4999,
+        name: "E2E Tests",
+        status: checkStatus.COMPLETED,
+        conclusion: checkConclusion.SUCCESS,
+        started_at: "2024-05-14T00:00:00Z",
+        completed_at: "2024-05-14T00:10:00Z",
+        check_suite: { id: 901 },
+        app: { id: 1001, slug: "github-actions", name: "GitHub Actions" },
+      };
+
+      getAllChecksMock.mockResolvedValueOnce([supersededFailure, freshSuccess]);
+      getWorkflowRunsForCommitMock.mockResolvedValueOnce([
+        { id: 100, workflow_id: 50, check_suite_id: 900 },
+        { id: 200, workflow_id: 50, check_suite_id: 901 },
+      ]);
+
+      const checks = new Checks(defaultProps);
+      await checks.fetchAllChecks();
+      await checks.filterChecks();
+
+      const filteredChecksExcludingOwnCheck = checks["filteredChecks"].filter(
+        (check: ICheck) => check.id !== checks["ownCheck"]?.id
+      );
+      const result = checks.evaluateChecksStatus(
+        filteredChecksExcludingOwnCheck
+      );
+
+      expect(result).toEqual({ in_progress: false, passed: true });
     });
 
     it("should filter statuses to most recent per context and creator", async () => {

--- a/__tests__/checks/checksAPI.test.ts
+++ b/__tests__/checks/checksAPI.test.ts
@@ -1,4 +1,7 @@
-import { getAllChecks } from "../../src/checks/checksAPI";
+import {
+  getAllChecks,
+  getWorkflowRunsForCommit,
+} from "../../src/checks/checksAPI";
 import * as octokitModule from "../../src/utils/octokit";
 import { ICheck } from "../../src/checks/checksInterfaces";
 import { checkStatus, checkConclusion } from "../../src/checks/checksConstants";
@@ -278,6 +281,62 @@ describe("checksAPI", () => {
       expect(result[1].conclusion).toBe(checkConclusion.FAILURE);
       expect(result[2].conclusion).toBe(checkConclusion.SKIPPED);
       expect(result[3].conclusion).toBe(checkConclusion.NEUTRAL);
+    });
+  });
+
+  describe("getWorkflowRunsForCommit", () => {
+    it("should fetch workflow runs for a commit SHA", async () => {
+      const mockApiResponse = [
+        {
+          id: 100,
+          workflow_id: 10,
+          check_suite_id: 500,
+          status: "completed",
+          conclusion: "success",
+          extra_field: "ignored",
+        },
+        {
+          id: 200,
+          workflow_id: 20,
+          check_suite_id: 600,
+          status: "completed",
+          conclusion: "failure",
+          extra_field: "also ignored",
+        },
+      ];
+
+      paginateMock.mockResolvedValue(mockApiResponse);
+
+      const result = await getWorkflowRunsForCommit("owner", "repo", "abc123");
+
+      expect(paginateMock).toHaveBeenCalledWith(
+        "GET /repos/:owner/:repo/actions/runs",
+        {
+          owner: "owner",
+          repo: "repo",
+          head_sha: "abc123",
+        }
+      );
+      expect(result).toEqual([
+        { id: 100, workflow_id: 10, check_suite_id: 500 },
+        { id: 200, workflow_id: 20, check_suite_id: 600 },
+      ]);
+    });
+
+    it("should throw error when API call fails", async () => {
+      paginateMock.mockRejectedValue(new Error("API Error"));
+
+      await expect(
+        getWorkflowRunsForCommit("owner", "repo", "abc123")
+      ).rejects.toThrow("Error getting workflow runs for commit: API Error");
+    });
+
+    it("should return empty array when no workflow runs exist", async () => {
+      paginateMock.mockResolvedValue([]);
+
+      const result = await getWorkflowRunsForCommit("owner", "repo", "abc123");
+
+      expect(result).toEqual([]);
     });
   });
 });

--- a/__tests__/checks/filter_tests/filterSupersededWorkflowRunChecks.test.ts
+++ b/__tests__/checks/filter_tests/filterSupersededWorkflowRunChecks.test.ts
@@ -1,0 +1,197 @@
+import { filterSupersededWorkflowRunChecks } from "../../../src/checks/checksFilters";
+import { ICheck, IWorkflowRun } from "../../../src/checks/checksInterfaces";
+import {
+  checkConclusion,
+  checkStatus,
+} from "../../../src/checks/checksConstants";
+
+function makeCheck(overrides: Partial<ICheck> & { id: number }): ICheck {
+  return {
+    name: "job",
+    status: checkStatus.COMPLETED,
+    conclusion: checkConclusion.SUCCESS,
+    started_at: "2024-01-01T00:00:00Z",
+    completed_at: "2024-01-01T00:01:00Z",
+    check_suite: { id: 100 },
+    app: { id: 1, slug: "github-actions", name: "GitHub Actions" },
+    ...overrides,
+  };
+}
+
+function makeWorkflowRun(
+  overrides: Partial<IWorkflowRun> & { id: number }
+): IWorkflowRun {
+  return {
+    workflow_id: 1,
+    check_suite_id: 100,
+    ...overrides,
+  };
+}
+
+describe("filterSupersededWorkflowRunChecks", () => {
+  it("should return all checks when workflowRuns is empty", () => {
+    const checks = [makeCheck({ id: 1 }), makeCheck({ id: 2 })];
+
+    const result = filterSupersededWorkflowRunChecks(checks, []);
+
+    expect(result).toEqual(checks);
+  });
+
+  it("should return all checks when each workflow has only one run", () => {
+    const checks = [
+      makeCheck({ id: 1, check_suite: { id: 500 } }),
+      makeCheck({ id: 2, check_suite: { id: 600 } }),
+    ];
+    const workflowRuns = [
+      makeWorkflowRun({ id: 100, workflow_id: 10, check_suite_id: 500 }),
+      makeWorkflowRun({ id: 200, workflow_id: 20, check_suite_id: 600 }),
+    ];
+
+    const result = filterSupersededWorkflowRunChecks(checks, workflowRuns);
+
+    expect(result).toEqual(checks);
+  });
+
+  it("should filter out checks from a superseded run when same workflow has two runs", () => {
+    const supersededCheck = makeCheck({
+      id: 1,
+      name: "build",
+      check_suite: { id: 500 },
+      conclusion: checkConclusion.FAILURE,
+    });
+    const latestCheck = makeCheck({
+      id: 2,
+      name: "build",
+      check_suite: { id: 600 },
+      conclusion: checkConclusion.SUCCESS,
+    });
+    const checks = [supersededCheck, latestCheck];
+
+    const workflowRuns = [
+      makeWorkflowRun({ id: 100, workflow_id: 10, check_suite_id: 500 }),
+      makeWorkflowRun({ id: 200, workflow_id: 10, check_suite_id: 600 }),
+    ];
+
+    const result = filterSupersededWorkflowRunChecks(checks, workflowRuns);
+
+    expect(result).toEqual([latestCheck]);
+  });
+
+  it("should keep checks from latest run per workflow when multiple workflows exist", () => {
+    const checks = [
+      makeCheck({ id: 1, name: "build", check_suite: { id: 500 } }),
+      makeCheck({ id: 2, name: "build", check_suite: { id: 600 } }),
+      makeCheck({ id: 3, name: "lint", check_suite: { id: 700 } }),
+      makeCheck({ id: 4, name: "lint", check_suite: { id: 800 } }),
+    ];
+    const workflowRuns = [
+      makeWorkflowRun({ id: 100, workflow_id: 10, check_suite_id: 500 }),
+      makeWorkflowRun({ id: 200, workflow_id: 10, check_suite_id: 600 }),
+      makeWorkflowRun({ id: 300, workflow_id: 20, check_suite_id: 700 }),
+      makeWorkflowRun({ id: 400, workflow_id: 20, check_suite_id: 800 }),
+    ];
+
+    const result = filterSupersededWorkflowRunChecks(checks, workflowRuns);
+
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual(
+      expect.objectContaining({ id: 2, check_suite: { id: 600 } })
+    );
+    expect(result).toContainEqual(
+      expect.objectContaining({ id: 4, check_suite: { id: 800 } })
+    );
+  });
+
+  it("should keep checks from non-GitHub-Actions apps whose suite ID is not in any workflow run", () => {
+    const ghActionsCheck = makeCheck({
+      id: 1,
+      name: "build",
+      check_suite: { id: 500 },
+    });
+    const thirdPartyCheck = makeCheck({
+      id: 2,
+      name: "codecov",
+      check_suite: { id: 999 },
+      app: { id: 50, slug: "codecov", name: "Codecov" },
+    });
+    const checks = [ghActionsCheck, thirdPartyCheck];
+
+    const workflowRuns = [
+      makeWorkflowRun({ id: 100, workflow_id: 10, check_suite_id: 500 }),
+    ];
+
+    const result = filterSupersededWorkflowRunChecks(checks, workflowRuns);
+
+    expect(result).toEqual(checks);
+  });
+
+  it("should handle issue #104: re-run check has higher ID but belongs to superseded run", () => {
+    const rerunCheck = makeCheck({
+      id: 5000,
+      name: "E2E Tests",
+      check_suite: { id: 900 },
+      conclusion: checkConclusion.FAILURE,
+    });
+    const freshCheck = makeCheck({
+      id: 4999,
+      name: "E2E Tests",
+      check_suite: { id: 901 },
+      conclusion: checkConclusion.SUCCESS,
+    });
+    const checks = [rerunCheck, freshCheck];
+
+    const workflowRuns = [
+      makeWorkflowRun({
+        id: 100,
+        workflow_id: 50,
+        check_suite_id: 900,
+      }),
+      makeWorkflowRun({
+        id: 200,
+        workflow_id: 50,
+        check_suite_id: 901,
+      }),
+    ];
+
+    const result = filterSupersededWorkflowRunChecks(checks, workflowRuns);
+
+    expect(result).toEqual([freshCheck]);
+    expect(result).not.toContainEqual(
+      expect.objectContaining({ conclusion: checkConclusion.FAILURE })
+    );
+  });
+
+  it("should only filter superseded workflows, leaving others unaffected", () => {
+    const supersededCheck = makeCheck({
+      id: 1,
+      name: "build",
+      check_suite: { id: 500 },
+      conclusion: checkConclusion.FAILURE,
+    });
+    const latestCheck = makeCheck({
+      id: 2,
+      name: "build",
+      check_suite: { id: 600 },
+      conclusion: checkConclusion.SUCCESS,
+    });
+    const unrelatedCheck = makeCheck({
+      id: 3,
+      name: "deploy",
+      check_suite: { id: 700 },
+    });
+    const checks = [supersededCheck, latestCheck, unrelatedCheck];
+
+    const workflowRuns = [
+      makeWorkflowRun({ id: 100, workflow_id: 10, check_suite_id: 500 }),
+      makeWorkflowRun({ id: 200, workflow_id: 10, check_suite_id: 600 }),
+      makeWorkflowRun({ id: 300, workflow_id: 20, check_suite_id: 700 }),
+    ];
+
+    const result = filterSupersededWorkflowRunChecks(checks, workflowRuns);
+
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual(expect.objectContaining({ id: 2 }));
+    expect(result).toContainEqual(expect.objectContaining({ id: 3 }));
+    expect(result).not.toContainEqual(expect.objectContaining({ id: 1 }));
+  });
+});

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -31,6 +31,7 @@ jest.mock("../src/utils/inputsExtractor", () => ({
     delay: 0,
     checkRunId: undefined,
     includeStatusCommits: false,
+    ignoreSupersededRuns: false,
   },
 }));
 

--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,10 @@ inputs:
     description: "If set to true, the action will log a summary of the checks that were evaluated"
     required: false
     default: "true"
+  ignore_superseded_runs:
+    description: "If set to true, checks from GitHub Actions will be grouped by workflow run and only the latest run per workflow will be evaluated. This filters out stale checks from superseded or re-run workflows"
+    required: false
+    default: "false"
   check_run_id:
     description: "This is the check run id of the current job, there is no need to set this (and setting it will actually cause a problem), the action will automatically set it for you. This is used to exclude the current job from the evaluation"
     required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "allcheckspassed",
-  "version": "2.1.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "allcheckspassed",
-      "version": "2.1.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/src/checks/checks.ts
+++ b/src/checks/checks.ts
@@ -1,6 +1,6 @@
 import * as core from "@actions/core";
 import { IInputs } from "../utils/inputsExtractor";
-import { getAllChecks } from "./checksAPI";
+import { getAllChecks, getWorkflowRunsForCommit } from "./checksAPI";
 import { getAllStatusCommits } from "../statuses/statusesAPI";
 import { mapStatusesToChecksModel } from "../statuses/statuses";
 import { addCommitStatusEmoji } from "../statuses/statusesConstants";
@@ -12,6 +12,7 @@ import {
 import {
   checkOneOfTheChecksInputIsEmpty,
   filterChecksWithMatchingNameAndAppId,
+  filterSupersededWorkflowRunChecks,
   removeChecksWithMatchingNameAndAppId,
   removeDuplicateChecksEntriesFromSelf,
   removeDuplicateEntriesChecksInputsFromSelf,
@@ -80,7 +81,21 @@ export default class Checks {
     try {
       let checks = await getAllChecks(this.owner, this.repo, this.ref);
 
-      // if the user wanted us to include the commit statuses as well, then we will fetch them and add them to the checks
+      try {
+        const workflowRuns = await getWorkflowRunsForCommit(
+          this.owner,
+          this.repo,
+          this.ref
+        );
+        checks = filterSupersededWorkflowRunChecks(checks, workflowRuns);
+      } catch (error: any) {
+        core.warning(
+          "Could not fetch workflow runs to filter superseded checks, " +
+            "proceeding with all checks: " +
+            error.message
+        );
+      }
+
       if (this.includeStatusCommits) {
         let statusCommits = await getAllStatusCommits(
           this.owner,

--- a/src/checks/checks.ts
+++ b/src/checks/checks.ts
@@ -57,6 +57,7 @@ export default class Checks {
   private verbose: boolean;
   private showJobSummary: boolean;
   private includeStatusCommits: boolean;
+  private ignoreSupersededRuns: boolean;
 
   constructor(props: IRepo & IInputs) {
     this.owner = props.owner;
@@ -75,25 +76,28 @@ export default class Checks {
     this.verbose = props.verbose;
     this.showJobSummary = props.showJobSummary;
     this.includeStatusCommits = props.includeStatusCommits;
+    this.ignoreSupersededRuns = props.ignoreSupersededRuns;
   }
 
   async fetchAllChecks() {
     try {
       let checks = await getAllChecks(this.owner, this.repo, this.ref);
 
-      try {
-        const workflowRuns = await getWorkflowRunsForCommit(
-          this.owner,
-          this.repo,
-          this.ref
-        );
-        checks = filterSupersededWorkflowRunChecks(checks, workflowRuns);
-      } catch (error: any) {
-        core.warning(
-          "Could not fetch workflow runs to filter superseded checks, " +
-            "proceeding with all checks: " +
-            error.message
-        );
+      if (this.ignoreSupersededRuns) {
+        try {
+          const workflowRuns = await getWorkflowRunsForCommit(
+            this.owner,
+            this.repo,
+            this.ref
+          );
+          checks = filterSupersededWorkflowRunChecks(checks, workflowRuns);
+        } catch (error: any) {
+          core.warning(
+            "Could not fetch workflow runs to filter superseded checks, " +
+              "proceeding with all checks: " +
+              error.message
+          );
+        }
       }
 
       if (this.includeStatusCommits) {

--- a/src/checks/checksAPI.ts
+++ b/src/checks/checksAPI.ts
@@ -1,5 +1,5 @@
 import { restClient } from "../utils/octokit";
-import { ICheck } from "./checksInterfaces";
+import { ICheck, IWorkflowRun } from "./checksInterfaces";
 
 export async function getAllChecks(
   owner: string,
@@ -18,5 +18,31 @@ export async function getAllChecks(
     return checks as ICheck[];
   } catch (error: any) {
     throw new Error("Error getting all checks: " + error.message);
+  }
+}
+
+export async function getWorkflowRunsForCommit(
+  owner: string,
+  repo: string,
+  headSha: string
+): Promise<IWorkflowRun[]> {
+  try {
+    let runs = await restClient.paginate(
+      "GET /repos/:owner/:repo/actions/runs",
+      {
+        owner,
+        repo,
+        head_sha: headSha,
+      }
+    );
+    return (runs as any[]).map((run) => ({
+      id: run.id,
+      workflow_id: run.workflow_id,
+      check_suite_id: run.check_suite_id,
+    }));
+  } catch (error: any) {
+    throw new Error(
+      "Error getting workflow runs for commit: " + error.message
+    );
   }
 }

--- a/src/checks/checksFilters.ts
+++ b/src/checks/checksFilters.ts
@@ -1,4 +1,4 @@
-import { ICheck, ICheckInput } from "./checksInterfaces";
+import { ICheck, ICheckInput, IWorkflowRun } from "./checksInterfaces";
 
 export enum FilterTypes {
   exclude = "exclude",
@@ -151,6 +151,35 @@ export function removeDuplicateChecksEntriesFromSelf(
     }
   });
   return uniqueChecks;
+}
+
+export function filterSupersededWorkflowRunChecks(
+  checks: ICheck[],
+  workflowRuns: IWorkflowRun[]
+): ICheck[] {
+  if (workflowRuns.length === 0) {
+    return checks;
+  }
+
+  const latestRunPerWorkflow = new Map<number, IWorkflowRun>();
+  for (const run of workflowRuns) {
+    const existing = latestRunPerWorkflow.get(run.workflow_id);
+    if (!existing || run.id > existing.id) {
+      latestRunPerWorkflow.set(run.workflow_id, run);
+    }
+  }
+
+  const latestSuiteIds = new Set(
+    Array.from(latestRunPerWorkflow.values()).map((r) => r.check_suite_id)
+  );
+  const allSuiteIds = new Set(workflowRuns.map((r) => r.check_suite_id));
+  const supersededSuiteIds = new Set(
+    [...allSuiteIds].filter((id) => !latestSuiteIds.has(id))
+  );
+
+  return checks.filter(
+    (check) => !supersededSuiteIds.has(check.check_suite.id)
+  );
 }
 
 export function filterChecksByStatus(checks: ICheck[], status: string) {

--- a/src/checks/checksInterfaces.ts
+++ b/src/checks/checksInterfaces.ts
@@ -26,3 +26,9 @@ export interface IDetermineChecksStatus {
   in_progress: boolean;
   passed: boolean;
 }
+
+export interface IWorkflowRun {
+  id: number;
+  workflow_id: number;
+  check_suite_id: number;
+}

--- a/src/utils/inputsExtractor.ts
+++ b/src/utils/inputsExtractor.ts
@@ -26,6 +26,7 @@ export interface IInputs {
   showJobSummary: boolean;
   checkRunId?: number | undefined;
   includeStatusCommits: boolean;
+  ignoreSupersededRuns: boolean;
 }
 
 function inputsParser(): IInputs {
@@ -70,6 +71,8 @@ function inputsParser(): IInputs {
     parseInt(core.getInput("check_run_id")) || undefined;
   const includeStatusCommits: boolean =
     core.getInput("include_status_commits") == "true";
+  const ignoreSupersededRuns: boolean =
+    core.getInput("ignore_superseded_runs") == "true";
 
   return {
     commitSHA,
@@ -88,6 +91,7 @@ function inputsParser(): IInputs {
     showJobSummary,
     checkRunId,
     includeStatusCommits,
+    ignoreSupersededRuns,
   };
 }
 


### PR DESCRIPTION
This pull request updates the workflow logic to exclude check runs associated with superseded workflow re-runs. This ensures that only relevant and active check runs are processed, avoiding clutter and potential confusion in the results.

Resolves https://github.com/wechuli/allcheckspassed/issues/104