### PR TITLE
Update README and upgrade GitHub Actions for evaluation modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
       contents: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: install nodejs
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.4.0"
           cache: "npm"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -64,7 +64,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -92,6 +92,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: install nodejs
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.4.0"
           cache: "npm"

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Git config

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The action works well with the `pull_request` or `pull_request_target` events. Y
 name: All checks pass
 on:
   pull_request:
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   allchecks:
@@ -69,6 +69,18 @@ jobs:
       statuses: read
 ```
 
+If you enable the `ignore_superseded_runs` option (see [Ignore superseded workflow runs](#ignore-superseded-workflow-runs) below), the action additionally calls the GitHub Actions Runs API, which requires the `actions: read` permission:
+
+```yaml
+jobs:
+  allchecks:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+      actions: read
+```
+
 ## Examples
 
 ### Exclude certain checks from causing a failure
@@ -77,10 +89,10 @@ You can exclude certain checks from causing a failure by using the `checks_exclu
 separated string of values:
 
 ```yaml
-    steps:
-      - uses: wechuli/allcheckspassed@v2
-        with:
-          checks_exclude: 'CodeQL,lint,cosmetic'
+steps:
+  - uses: wechuli/allcheckspassed@v2
+    with:
+      checks_exclude: "CodeQL,lint,cosmetic"
 ```
 
 You might want to do this to allow certain checks to fail, such as a code quality check, but still require that all
@@ -90,10 +102,10 @@ The `checks_exclude` and `checks_include` inputs support Regular Expressions. Fo
 checks have the word `lint` somewhere in the string, you don't have to list them all out, you can use the following:
 
 ```yaml
-    steps:
-      - uses: wechuli/allcheckspassed@v2
-        with:
-          checks_exclude: '.*lint.*'
+steps:
+  - uses: wechuli/allcheckspassed@v2
+    with:
+      checks_exclude: ".*lint.*"
 ```
 
 ### Include only certain checks
@@ -103,10 +115,10 @@ for this action, but it is possible. If you want the check to always be included
 repository rulesets or branch protection rules. You can't provide both the `checks_include` and `checks_exclude`inputs.
 
 ```yaml
-    steps:
-      - uses: wechuli/allcheckspassed@v2
-        with:
-          checks_include: 'CodeQL'
+steps:
+  - uses: wechuli/allcheckspassed@v2
+    with:
+      checks_include: "CodeQL"
 ```
 
 ### What should be considered as passing
@@ -130,10 +142,10 @@ If you define one or more checks in the `checks_include` input, the action will 
 are missing. You can choose instead to fail the action if any of the checks are missing:
 
 ```yaml
-    steps:
-      - uses: wechuli/allcheckspassed@v2
-        with:
-          fail_on_missing_checks: true
+steps:
+  - uses: wechuli/allcheckspassed@v2
+    with:
+      fail_on_missing_checks: true
 ```
 
 ### Time
@@ -143,13 +155,12 @@ retries) with a delay
 between each poll of 1 minute (default). You can change these values to your liking:
 
 ```yaml
-    steps:
-      - uses: wechuli/allcheckspassed@v2
-        with:
-          delay: '5'
-          retries: '3'
-          polling_interval: '3'
-
+steps:
+  - uses: wechuli/allcheckspassed@v2
+    with:
+      delay: "5"
+      retries: "3"
+      polling_interval: "3"
 ```
 
 When the step with the action runs, it will wait for 5 minutes before polling the API for the first time. It will then
@@ -158,11 +169,10 @@ poll the API 3 times with a delay of 3 minutes between each poll.
 You also don't have to poll, you can just run the action once and get the result.
 
 ```yaml
-    steps:
-      - uses: wechuli/allcheckspassed@v2
-        with:
-          poll: false
-
+steps:
+  - uses: wechuli/allcheckspassed@v2
+    with:
+      poll: false
 ```
 
 ### Fail Fast
@@ -175,11 +185,10 @@ used to cause this action to report a failure status as soon as one other check 
 for all checks to complete before reporting a failure, you can set the fail_fast flag to false.
 
 ```yaml
-    steps:
-      - uses: wechuli/allcheckspassed@v2
-        with:
-          fail_fast: false
-
+steps:
+  - uses: wechuli/allcheckspassed@v2
+    with:
+      fail_fast: false
 ```
 
 ### Verbose logging
@@ -189,35 +198,66 @@ logs will indicate which specific checks are being waited on in each polling ite
 what checks are matched by `checks_include` or `checks_exclude`.
 
 ```yaml
-    steps:
-      - uses: wechuli/allcheckspassed@v2
-        with:
-          verbose: true
+steps:
+  - uses: wechuli/allcheckspassed@v2
+    with:
+      verbose: true
 ```
 
 ### Job summary
 
-By default, the action will create a job summary with the details of each check that was evaluated and their status. You can disable the job summary by setting  the `show_job_summary` input to false. This will prevent the action from creating a job summary at the end of the workflow run.
+By default, the action will create a job summary with the details of each check that was evaluated and their status. You can disable the job summary by setting the `show_job_summary` input to false. This will prevent the action from creating a job summary at the end of the workflow run.
 
 ```yaml
-    steps:
-      - uses: wechuli/allcheckspassed@v2
-        with:
-          show_job_summary: false
+steps:
+  - uses: wechuli/allcheckspassed@v2
+    with:
+      show_job_summary: false
 ```
 
 ### Status Commits
 
-You can choose to include commit statuses in addition to checks for evaluation. By default, this is disabled. If your CI/CD is only ever running on GitHub Actions and you are not explicitly calling the commit status API, then that option can be left to default to false as is. If you have an external integration (such as Jenkins) that is reporting commit statuses instead of checks, you can set the `include_commit_statuses` option to `true` so that those are evaluated as well. 
+You can choose to include commit statuses in addition to checks for evaluation. By default, this is disabled. If your CI/CD is only ever running on GitHub Actions and you are not explicitly calling the commit status API, then that option can be left to default to false as is. If you have an external integration (such as Jenkins) that is reporting commit statuses instead of checks, you can set the `include_commit_statuses` option to `true` so that those are evaluated as well.
 
 ```yaml
+steps:
+  - uses: wechuli/allcheckspassed@v2
+    with:
+      include_commit_statuses: true
+```
+
+Checks and status commits use a different API and there are some nuances to be aware of. More on this is documented at [./docs/adrs/commit_status.md](./docs/adrs/commit_status.md)
+
+### Ignore superseded workflow runs
+
+By default, the action evaluates every check run that the Checks API returns for the commit and deduplicates by `(check name, app id)`. This means that if a GitHub Actions workflow is re-run on the same commit, stale check runs from the older run may still be evaluated when their names do not exactly match the new run (for example, matrix jobs in a cancelled run whose templates were never expanded). See [#104](https://github.com/wechuli/allcheckspassed/issues/104) for a real-world example.
+
+You can opt in to filtering check runs down to the latest GitHub Actions run per workflow on the commit by setting `ignore_superseded_runs` to `true`:
+
+```yaml
+steps:
+  - uses: wechuli/allcheckspassed@v2
+    with:
+      ignore_superseded_runs: true
+```
+
+When this is enabled, the action calls `GET /repos/:owner/:repo/actions/runs?head_sha=<sha>` in addition to the Checks API, so the workflow must grant the **`actions: read`** permission:
+
+```yaml
+jobs:
+  allchecks:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+      actions: read
     steps:
       - uses: wechuli/allcheckspassed@v2
         with:
-          include_commit_statuses: true
+          ignore_superseded_runs: true
 ```
-Checks and status commits use a different API and there are some nuances to be aware of. More on this is documented at [./docs/adrs/commit_status.md](./docs/adrs/commit_status.md)
 
+This mode and the default raw-checks mode behave differently in some edge cases (notably around manually-created check runs that live in cancelled check suites). The two modes, what each one does, and guidance on when to use which are documented in [./docs/adrs/evaluation_modes.md](./docs/adrs/evaluation_modes.md).
 
 ## Setup with environments
 
@@ -235,9 +275,9 @@ a long time.
 jobs:
   allchecks:
     runs-on: ubuntu-latest
-    environment: 
-       name: delayenv
-       deployment: false
+    environment:
+      name: delayenv
+      deployment: false
     steps:
       - uses: wechuli/allcheckspassed@v2
         with:

--- a/docs/adrs/evaluation_modes.md
+++ b/docs/adrs/evaluation_modes.md
@@ -1,0 +1,75 @@
+# Checks Evaluation Modes
+
+This action supports two modes for deciding which check runs on a commit should be evaluated. The mode is controlled by the `ignore_superseded_runs` input, which defaults to `false` to preserve the historical behavior.
+
+| Mode                  | Input                                     | Source APIs              | Extra permissions                             |
+| --------------------- | ----------------------------------------- | ------------------------ | --------------------------------------------- |
+| Default (raw checks)  | `ignore_superseded_runs: false` (default) | Checks API only          | None beyond `checks: read` / `contents: read` |
+| Workflow-run grouping | `ignore_superseded_runs: true`            | Checks API + Actions API | Adds `actions: read`                          |
+
+## Mode 1 — Default (raw checks evaluation)
+
+This is the original and default behavior.
+
+How it works:
+
+1. The action calls `GET /repos/:owner/:repo/commits/:ref/check-runs` to list every check run attached to the commit.
+2. After applying `checks_include` / `checks_exclude`, it deduplicates checks by `(check_name, app_id)`, keeping the check run with the highest check run ID (the most recent attempt for that exact name and app).
+3. Whatever remains is evaluated against the success / failure rules.
+
+Characteristics:
+
+- Does not look at workflow runs or check suites — it operates on the raw list of check runs on the commit.
+- Catches check runs created by any GitHub App, including ones created manually via the Checks API. This is particularly relevant for check runs created via the `GITHUB_TOKEN` from inside a GitHub Actions workflow: those check runs are attached to the GitHub Actions bot's check suite for that workflow run, and if that workflow run is cancelled or superseded, the check runs can appear "hidden" in the Actions UI. They are still returned by the Checks API and are evaluated by this action. (Note: this only applies to the GitHub Actions bot, because GitHub creates a separate check suite per workflow run for it. Any other GitHub App has exactly one check suite per commit SHA, so its check runs always live on that single suite and the "hidden" scenario does not apply.) See [community discussion #14891](https://github.com/orgs/community/discussions/14891) for background.
+- The dedup is by `(name, app_id)`. If a re-run of a GitHub Actions workflow produces check runs whose names do **not** exactly match the names from the newer run (for example, jobs in a cancelled run whose matrix template was never expanded, so the name still contains `${{ matrix.foo }}`), both the stale and the fresh check runs survive dedup and are evaluated. A stale failure can then cause this action to report a failure even though the equivalent job passed in the newer run. This is the scenario reported in [#104](https://github.com/wechuli/allcheckspassed/issues/104).
+
+When to use this mode:
+
+- You want the safest default that matches what GitHub returns on the commit.
+- You rely on check runs created by integrations or manual API calls that may live in cancelled / superseded check suites, and you do not want them silently dropped.
+- You cannot grant the workflow `actions: read`.
+
+## Mode 2 — Workflow-run grouping (`ignore_superseded_runs: true`)
+
+This mode is opt-in and was added to address [#104](https://github.com/wechuli/allcheckspassed/issues/104) via [#105](https://github.com/wechuli/allcheckspassed/pull/105).
+
+How it works:
+
+1. The action calls `GET /repos/:owner/:repo/commits/:ref/check-runs` to list all check runs on the commit (same as Mode 1).
+2. It additionally calls `GET /repos/:owner/:repo/actions/runs?head_sha=<sha>` to list every GitHub Actions workflow run for the commit.
+3. Workflow runs are grouped by `workflow_id`. For each `workflow_id`, only the run with the highest run `id` (the latest attempt of that workflow) is kept. The check suites belonging to all the other (superseded) runs are marked as stale.
+4. Any check run whose `check_suite.id` belongs to a superseded check suite is filtered out before the rest of the evaluation pipeline runs.
+5. The remaining checks then go through the same `checks_include` / `checks_exclude` filtering and `(name, app_id)` dedup as Mode 1.
+
+Characteristics:
+
+- Removes the entire set of check runs that belong to a superseded GitHub Actions workflow run, regardless of name. This fixes the case in [#104](https://github.com/wechuli/allcheckspassed/issues/104) where stale check runs (e.g., from a cancelled run with unexpanded matrix templates, or from a previous re-run with expired artifacts) had names that did not match the new run and therefore were not removed by the `(name, app_id)` dedup.
+- The filtering only targets the GitHub Actions bot's check suites (one per workflow run). Check suites for other GitHub Apps are not affected, because each non-Actions app has exactly one check suite per commit SHA and that suite is never marked superseded. The trade-off is specifically for check runs created via the `GITHUB_TOKEN` from inside a workflow that ends up superseded — those will be filtered out along with the rest of that workflow run's checks. If you depend on such check runs surviving a superseded run, prefer Mode 1.
+- Requires the workflow to have `actions: read` permission. Without it, the call to `GET /repos/:owner/:repo/actions/runs` will fail or return an empty list, defeating the purpose of the mode.
+
+When to use this mode:
+
+- You have workflows that get re-run on the same commit (manual re-runs, concurrency-cancelled runs, etc.) and you want stale check runs from earlier runs to be ignored.
+- You only care about check runs that GitHub itself considers part of the latest run of each workflow on the commit.
+- You are able to grant `actions: read` to the job.
+
+## Example
+
+```yaml
+jobs:
+  allchecks:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+      actions: read # required only when ignore_superseded_runs is true
+    steps:
+      - uses: wechuli/allcheckspassed@v2
+        with:
+          ignore_superseded_runs: true
+```
+
+## Summary
+
+- Default mode is conservative: it evaluates every check run the Checks API returns for the commit, and never silently hides any of them.
+- `ignore_superseded_runs: true` is the right choice when stale GitHub Actions runs on the same commit are producing false failures, and you are comfortable scoping evaluation to the latest workflow run per workflow. It needs the extra `actions: read` permission.


### PR DESCRIPTION
This pull request updates GitHub Actions workflow dependencies to their latest major versions and adds improved documentation for a new evaluation mode that helps ignore stale check runs from superseded workflow runs. The documentation now explains how to use this mode, the required permissions, and the differences between the two evaluation strategies. Additionally, YAML and markdown formatting in the documentation has been standardized for better readability.